### PR TITLE
Remove user data and unused Fargate profile from EKS configuration

### DIFF
--- a/eks.tf
+++ b/eks.tf
@@ -47,33 +47,6 @@ resource "aws_eks_cluster" "m306" {
 
 }
 
-# Fargate Profile
-resource "aws_eks_fargate_profile" "m306" {
-  cluster_name           = aws_eks_cluster.m306.name
-  fargate_profile_name   = "m306-fargate-profile"
-  pod_execution_role_arn = data.aws_iam_role.labrole.arn
-  subnet_ids = [
-    aws_subnet.private_subnet_1.id,
-    aws_subnet.private_subnet_2.id,
-    aws_subnet.private_subnet_3.id
-  ]
-
-  selector {
-    namespace = "default"
-  }
-
-  selector {
-    namespace = "kube-system"
-  }
-
-  selector {
-    namespace = "m306"
-  }
-
-  selector {
-    namespace = "m306-staging"
-  }
-}
 
 # Managed Node Group for fast startup
 resource "aws_eks_node_group" "fast_nodes" {

--- a/eks.tf
+++ b/eks.tf
@@ -122,15 +122,7 @@ resource "aws_eks_node_group" "fast_nodes" {
 resource "aws_launch_template" "eks_fast_launch" {
   name = "eks-fast-launch"
 
-  # Simple user data for faster bootstrap - no MIME multipart needed
-  user_data = base64encode(<<-EOF
-#!/bin/bash
-/etc/eks/bootstrap.sh ${aws_eks_cluster.m306.name} \
-  --container-runtime containerd \
-  --kubelet-extra-args "--max-pods=110"
-EOF
-  )
-
+  # Remove user data - let EKS handle bootstrapping automatically
   vpc_security_group_ids = [aws_security_group.eks.id]
 
   tag_specifications {


### PR DESCRIPTION
Eliminate user data from the launch template to allow automatic EKS bootstrapping and remove the unused Fargate profile resource from the configuration.