### PR TITLE
Refactor AWS Load Balancer Controller and update RDS subnet group references

### DIFF
--- a/helm.tf
+++ b/helm.tf
@@ -149,37 +149,3 @@ resource "helm_release" "aws_load_balancer_controller" {
     aws_eks_node_group.fast_nodes
   ]
 }
-
-# AWS Load Balancer Controller
-resource "helm_release" "aws_load_balancer_controller" {
-  name       = "aws-load-balancer-controller"
-  repository = "https://aws.github.io/eks-charts"
-  chart      = "aws-load-balancer-controller"
-  namespace  = "kube-system"
-  version    = "1.13.2"
-
-  set {
-    name  = "clusterName"
-    value = aws_eks_cluster.m306.name
-  }
-
-  set {
-    name  = "serviceAccount.create"
-    value = "true"
-  }
-
-  set {
-    name  = "serviceAccount.name"
-    value = "aws-load-balancer-controller"
-  }
-
-  set {
-    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
-    value = data.aws_iam_role.labrole.arn
-  }
-
-  depends_on = [
-    aws_eks_cluster.m306,
-    aws_eks_node_group.fast_nodes
-  ]
-}

--- a/storage.tf
+++ b/storage.tf
@@ -12,7 +12,7 @@ resource "aws_rds_cluster" "m306" {
 
   # Network configuration
   vpc_security_group_ids = [aws_security_group.rds.id]
-  db_subnet_group_name   = aws_db_subnet_group.rds.name
+  db_subnet_group_name   = aws_db_subnet_group.rds_private.name
 }
 
 
@@ -25,8 +25,8 @@ resource "aws_rds_cluster_instance" "m306" {
 }
 
 # Create RDS subnet group using private subnets
-resource "aws_db_subnet_group" "rds" {
-  name = "m306-rds-subnet-group"
+resource "aws_db_subnet_group" "rds_private" {
+  name = "m306-rds-private-subnet-group"
   subnet_ids = [
     aws_subnet.private_subnet_1.id,
     aws_subnet.private_subnet_2.id,
@@ -34,7 +34,7 @@ resource "aws_db_subnet_group" "rds" {
   ]
 
   tags = {
-    Name = "m306-rds-subnet-group"
+    Name = "m306-rds-private-subnet-group"
   }
 }
 


### PR DESCRIPTION
Remove redundant resource definition for the AWS Load Balancer Controller and update the RDS subnet group to use the private subnet group instead of the public one.