### PR TITLE
Refactor AWS Load Balancer Controller service account and update Helm version

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -3,19 +3,3 @@ data "aws_iam_role" "labrole" {
 }
 
 data "aws_ecr_authorization_token" "token" {}
-
-# Create service account for AWS Load Balancer Controller using existing LabRole
-resource "kubernetes_service_account" "aws_load_balancer_controller" {
-  metadata {
-    name      = "aws-load-balancer-controller"
-    namespace = "kube-system"
-    annotations = {
-      "eks.amazonaws.com/role-arn" = data.aws_iam_role.labrole.arn
-    }
-  }
-
-  depends_on = [
-    aws_eks_cluster.m306,
-    aws_eks_node_group.fast_nodes
-  ]
-}


### PR DESCRIPTION
Remove the redundant service account for the AWS Load Balancer Controller and update the Helm release version to the latest.